### PR TITLE
Added options to customize --topn output format

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -20,7 +20,9 @@ parser.add_argument("--dataset", default=None, type=str,
 parser.add_argument("--device", default=None, type=int, help="CUDA device number; set to -1 for CPU.")
 parser.add_argument("--batch_size", default=32, type=int, help="The size of each prediction batch.")
 parser.add_argument("--raw_text", action="store_true", help="Input raw sentences, one per line in the input file.")
-parser.add_argument("--topn", default=None, type=int, help='Output the top-n labels and their probability.')
+parser.add_argument("--topn", default=None, type=int, help="Output the top-n labels and their probability.")
+parser.add_argument("--conn", default='=', type=str, help="With --topn, string inserted between each label and its probability.")
+parser.add_argument("--sep", default='|', type=str, help="With --topn, string inserted between label-probability pairs.")
 args = parser.parse_args()
 
 logger.info('cmd: ' + ' '.join(sys.argv) + '\n')
@@ -48,4 +50,4 @@ for dataIdx in range(0, len(args.file_paths), 2):
     input_path = args.file_paths[dataIdx]
     output_path = args.file_paths[dataIdx + 1]
     logger.info('predicting on ' + input_path + ', saving on ' + output_path)
-    predict2(model, input_path, output_path, args.dataset, args.batch_size, args.raw_text, device)
+    predict2(model, input_path, output_path, args.dataset, args.batch_size, args.raw_text, device, args.conn, args.sep)


### PR DESCRIPTION
User can choose their own connector (default =) and separator (default |) for label-probability pairs.

(I need this because our labels contain equals signs.)