### PR TITLE
Added --model_dir option

### DIFF
--- a/machamp/model/trainer.py
+++ b/machamp/model/trainer.py
@@ -47,7 +47,8 @@ def train(
         resume: str = None,
         retrain: str = None,
         seed: int = None,
-        cmd: str = ''):
+        cmd: str = '',
+        model_dir = None):
     """
     
     Parameters
@@ -71,6 +72,8 @@ def train(
         random package. 
     cmd: str = ''
         The command invoked to start the training
+    model_dir: str = None
+        Directory to save model and logs in, overrides default
     """
     start_time = datetime.datetime.now()
     first_epoch = 1
@@ -89,11 +92,14 @@ def train(
     else:
         parameters_config = myutils.load_json(parameters_config_path)
         dataset_configs = myutils.merge_configs(dataset_config_paths, parameters_config)
-        serialization_dir = 'logs/' + name + '/' + start_time.strftime("%Y.%m.%d_%H.%M.%S") + '/'
-        counter = 2
-        while os.path.isdir(serialization_dir):
-            serialization_dir += '.' + str(counter)
-            counter += 1
+        if model_dir:
+            serialization_dir = model_dir
+        else:
+            serialization_dir = 'logs/' + name + '/' + start_time.strftime("%Y.%m.%d_%H.%M.%S") + '/'
+            counter = 2
+            while os.path.isdir(serialization_dir):
+                serialization_dir += '.' + str(counter)
+                counter += 1
         os.makedirs(serialization_dir)
 
         if seed != None:

--- a/train.py
+++ b/train.py
@@ -16,9 +16,12 @@ parser.add_argument("--sequential", action="store_true",
 parser.add_argument("--parameters_config", default="configs/params.json", type=str,
                     help="Configuration file for parameters of the model.")
 parser.add_argument("--device", default=None, type=int, help="CUDA device; set to -1 for CPU.")
-parser.add_argument("--resume", default='', type=str,
-                    help='Finalize training on a model for which training abruptly stopped. Give the path to the log '
-                         'directory of the model.')
+model_dir_group = parser.add_mutually_exclusive_group()
+model_dir_group.add_argument("--resume", default='', type=str,
+                             help='Finalize training on a model for which training abruptly stopped. Give the path to the log '
+                                  'directory of the model.')
+model_dir_group.add_argument("--model_dir", default=None, type=str,
+                             help='Specify a directory to store model and logs in. Overrides the default.')
 parser.add_argument("--retrain", type=str, default='',
                     help="Retrain on an previously train MaChAmp model. Specify the path to model.tar.gz and add a "
                          "dataset_config that specifies the new training.")
@@ -50,7 +53,7 @@ if args.sequential:
                             args.seed, cmd)
     for datasetIdx, dataset in enumerate(args.dataset_configs[1:]):
         modelName = name + '.' + str(datasetIdx + 1)
-        prevDir = trainer.train(modelName, args.parameters_config, [dataset], device, None, prevDir, args.seed, cmd)
+        prevDir = trainer.train(modelName, args.parameters_config, [dataset], device, None, prevDir, args.seed, cmd, args.model_dir)
 
 else:
-    trainer.train(name, args.parameters_config, args.dataset_configs, device, args.resume, args.retrain, args.seed, cmd)
+    trainer.train(name, args.parameters_config, args.dataset_configs, device, args.resume, args.retrain, args.seed, cmd, args.model_dir)


### PR DESCRIPTION
If the --model_dir option is specified, instead of the default logs/$name/$datetime, logs and models are stored in the specified directory. This offers more control, e.g., when the user wants to use MaChAmp in the context of a larger experiment management system.

When --model_dir is not given, everything should work unchanged.