### PR TITLE
Probdistr

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,4 +1,5 @@
 Functionality:
+- tqdm for prediction?
 - Tokenization for tokenizers that do not use ## or ▁, for example luke-large (the EN version)
 - Metrics might be broken (accuracy is), because of distinction between UNK/PAD
 - freeze or random seems to be broken (if frozen and random performance is still high): guess its freezing
@@ -13,7 +14,7 @@ Clean later:
 - remove scalars parameters warning
 - Fix wiki.sh?
 - "." can not be part of a task name because of scalars dict, should scalars be in task_decoders?
-- Remove dependency on numpy
+- Remove dependency on numpy (/jsonnet?)
 - FutureWarning: This implementation of AdamW is deprecated.  Use the PyTorch implementation torch.optim.AdamW instead
 - Add support for parameter overriding from command line: python3 train.py --dataset_config configs/ewt.json --parameter transformer_model=xlm-roberta-large,batching.sampling_smoothing=0.5
 - output all tasks with predict somehow

--- a/TODO
+++ b/TODO
@@ -18,6 +18,8 @@ Clean later:
 - FutureWarning: This implementation of AdamW is deprecated.  Use the PyTorch implementation torch.optim.AdamW instead
 - Add support for parameter overriding from command line: python3 train.py --dataset_config configs/ewt.json --parameter transformer_model=xlm-roberta-large,batching.sampling_smoothing=0.5
 - output all tasks with predict somehow
+- /home/robv/machamp/predict.py:45: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
+
 
 functionality later:
 - Tune threshold of multiseq and multiclas automatically

--- a/configs/distribution.json
+++ b/configs/distribution.json
@@ -1,0 +1,17 @@
+{
+  "Humans-and-genres": {
+    "train_data_path": "data/humans-and-domains/final_annotations/perlabel-sent-train.conll",
+    "dev_data_path": "data/humans-and-domains/final_annotations/perlabel-sent-dev.conll",
+    "skip_first_line": true,
+    "sent_idxs": [
+      1
+    ],
+    "tasks": {
+      "genre": {
+        "column_idxs": [2,3,4,5,6,7,8,9,10,11,12,13],
+        "task_type": "probdistr"
+      }
+    }
+  },
+}
+

--- a/configs/params.json
+++ b/configs/params.json
@@ -30,6 +30,9 @@
       "metric": "multi_acc",
       "threshold": 0.7
     },
+    "probdistr": {
+      "metric": "avg_dist"
+    },
     "multiseq": {
       "metric": "multi_acc",
       "threshold": 0.7

--- a/configs/params.json
+++ b/configs/params.json
@@ -1,8 +1,6 @@
 {
   "transformer_model": "bert-base-multilingual-cased",
-  //"transformer_model": "xlm-roberta-large",
   "reset_transformer_model": false,
-  "random_seed": 8446,
   "default_dec_dataset_embeds_dim": 12,
   "encoder": {
     "dropout": 0.2,

--- a/docs/new_task_type.md
+++ b/docs/new_task_type.md
@@ -15,5 +15,6 @@ Basically it involves four steps:
   to take a look at the most similar of the existing decoders in `machamp/models/`.
 * Make sure the `MachampModel` model forward pass passes the right encoding (sentence/word-level)
   to the right decoder.
-
+* Add conversion of gold labels to batches in `machamp/utils/myutils.py` in `prep_batch`
+* Prediction might not work by default, and might need some adaptation in `machamp/predictor/predict.py`
 

--- a/docs/seq_bio.md
+++ b/docs/seq_bio.md
@@ -2,8 +2,14 @@
 
 [back to main README](../README.md)
 
-The usage of this task type is similar as [seq](seq.md). However, this task type assumes that
-your data is in BIO format, and also guarantees that the output will be in valid BIO format.
-Under the hood it is using a masked CRF, which disallows ill-formed output. Performance can be
-expected to be higher for span labeling tasks (like NER) compared to the standard `seq` decoder.
+The usage of this task type is similar as [seq](seq.md). However, this task
+type assumes that your data is in BIO format, and also guarantees that the
+output will be in valid BIO format.  Under the hood it is using a masked CRF,
+which disallows ill-formed output. Performance can be expected to be higher for
+span labeling tasks (like NER) compared to the standard `seq` decoder.
+
+It should be noted that the prediction is still based on labels seen during
+training, so if a label only occurs as a B-label in training, the I-label will
+never be predicted. You can inspect the full vocabulary in the `vocabularies`
+directory inside a model directory for debugging purposes.
 

--- a/machamp/model/machamp.py
+++ b/machamp/model/machamp.py
@@ -89,7 +89,7 @@ class MachampModel(torch.nn.Module):
         # that would require adaptation for any future model types.
         # Or resetting of the prediction layer
         elif 'mlm' in task_types:
-            self.mlm = AutoModelForMaskedLM.from_pretrained(mlm)
+            self.mlm = AutoModelForMaskedLM.from_pretrained(mlm, trust_remote_code=False)
         else:
             self.mlm = AutoModel.from_pretrained(mlm)
 

--- a/machamp/model/machamp.py
+++ b/machamp/model/machamp.py
@@ -15,6 +15,7 @@ from machamp.metrics.perplexity import Perplexity
 from machamp.data.machamp_vocabulary import MachampVocabulary
 from machamp.model.classification_decoder import MachampClassificationDecoder
 from machamp.model.regression_decoder import MachampRegressionDecoder
+from machamp.model.probdistr_decoder import MachampProbdistributionDecoder
 from machamp.model.seq_label_decoder import MachampSeqDecoder
 from machamp.model.multiseq_decoder import MachampMultiseqDecoder
 from machamp.model.crf_label_decoder import MachampCRFDecoder
@@ -149,6 +150,8 @@ class MachampModel(torch.nn.Module):
 
             if task_type == 'classification':
                 decoder_type = MachampClassificationDecoder
+            if task_type == 'probdistr':
+                decoder_type = MachampProbdistributionDecoder
             elif task_type in ['seq', 'string2string', 'tok']:
                 decoder_type = MachampSeqDecoder
             elif task_type == 'seq_bio':
@@ -268,7 +271,7 @@ class MachampModel(torch.nn.Module):
             cur_task_types = self.task_types
         is_only_mlm = sum([task_type != 'mlm' for task_type in cur_task_types]) == 0
         is_only_classification = sum(
-            [task_type not in ['classification', 'regression', 'multiclas'] for task_type in cur_task_types]) == 0
+            [task_type not in ['probdistr', 'classification', 'regression', 'multiclas'] for task_type in cur_task_types]) == 0
         dont_split = is_only_mlm or is_only_classification
 
         # Run transformer model on input
@@ -279,7 +282,7 @@ class MachampModel(torch.nn.Module):
         mlm_out_token = None
         mlm_out_tok = None
 
-        if 'classification' in self.task_types or 'regression' in self.task_types or 'multiclas' in self.task_types:
+        if 'classification' in self.task_types or 'regression' in self.task_types or 'multiclas' in self.task_types or 'probdistr' in self.task_types:
             # always take first token, even if it is not a special token
             mlm_out_sent = mlm_out[:, :, :1, :].squeeze(2)
             if self.dropout != None:
@@ -321,7 +324,7 @@ class MachampModel(torch.nn.Module):
 
                 if task_type == 'mlm':# Not possible to apply scalar, already have predictions..
                     mlm_out_task = mlm_preds[:, 1:-1, :]
-                elif task_type in ['classification', 'regression', 'multiclas']:
+                elif task_type in ['classification', 'regression', 'multiclas', 'probdistr']:
                     mlm_out_task = myutils.apply_scalar(mlm_out_sent, self.layers[task], self.scalars[task])
                 elif task_type == 'tok':
                     mlm_out_task = myutils.apply_scalar(mlm_out_tok, self.layers[task], self.scalars[task])
@@ -460,7 +463,7 @@ class MachampModel(torch.nn.Module):
             if task_type == 'mlm':# Not possible to apply scalar, already have predictions..
                 continue# Not sure how to write labels, so no need to get them
                 #mlm_out_task = mlm_preds[:, 1:-1, :]
-            elif task_type in ['classification', 'regression', 'multiclas']:
+            elif task_type in ['classification', 'regression', 'multiclas', 'probdistr']:
                 mlm_out_task = myutils.apply_scalar(mlm_out_sent, self.layers[task], self.scalars[task])
             elif task_type == 'tok':
                 mlm_out_task = myutils.apply_scalar(mlm_out_tok, self.layers[task], self.scalars[task])

--- a/machamp/model/probdistr_decoder.py
+++ b/machamp/model/probdistr_decoder.py
@@ -1,0 +1,49 @@
+import torch
+import torch.nn.functional as F
+
+from machamp.model.machamp_decoder import MachampDecoder
+
+
+class MachampProbdistributionDecoder(MachampDecoder, torch.nn.Module):
+    def __init__(self, task, vocabulary, input_dim, device, loss_weight: float = 1.0, decoder_dropout: float = 0.0, topn: int = 1,
+                 metric: str = 'accuracy', **kwargs):
+        super().__init__(task, vocabulary, loss_weight, metric, device, **kwargs)
+
+        self.nlabels = len(kwargs['column_idxs'])
+        self.hidden_to_label = torch.nn.Linear(input_dim, self.nlabels)
+        self.hidden_to_label.to(device)
+        self.loss_function = torch.nn.CrossEntropyLoss(reduction='sum', ignore_index=-100)
+        # Not sure which loss to use, in the past we used multi_class_cross_entropy_loss and sequence_cross_entropy_with_logits from AllenNLP, 
+        # other options: nn.MSELoss nn.BCELoss
+        self.topn = topn
+
+        self.decoder_dropout = torch.nn.Dropout(decoder_dropout)
+        self.decoder_dropout.to(device)
+
+    def forward(self, mlm_out, mask, gold=None):
+        if self.topn != 1:
+            logger.warning('topn is not implemented for the probdistr task type, as it is unclear what it should do')
+
+        if self.decoder_dropout.p > 0.0:
+            mlm_out =  self.decoder_dropout(mlm_out) 
+
+        logits = self.hidden_to_label(mlm_out)
+        out_dict = {'logits': logits}
+        if type(gold) != type(None):
+            self.metric.score(logits, gold, None, mask)
+            if self.additional_metrics:
+                for additional_metric in self.additional_metrics:
+                    additional_metric.score(maxes, gold, None, self.vocabulary.inverse_namespaces[self.task], None)
+            out_dict['loss'] = self.loss_weight * self.loss_function(logits, gold)
+        return out_dict
+
+    def get_output_labels(self, mlm_out, mask, gold=None):
+        logits = self.forward(mlm_out, mask, gold)['logits']
+        # logits is a matrix of batch_size * n_labels
+        # however, the predictor expects strings, not sure how to most
+        # easily do this,  as they should be written to different columns..
+        # probably just using a list and an exception in the predictor 
+        # would do the trick
+
+        return {'sent_labels': [str(x.item()) for x in logits]}
+

--- a/machamp/utils/myutils.py
+++ b/machamp/utils/myutils.py
@@ -144,6 +144,9 @@ def prep_batch(
             golds[task] = torch.full((batch_size, max_subword_len - 2), -100, dtype=torch.long, device=device)
         elif task_type == 'regression':
             golds[task] = torch.full((batch_size,), -100, dtype=torch.float, device=device)
+        elif task_type == 'probdistr':
+            num_labels = len(batch[0].golds[task])
+            golds[task] = torch.full((batch_size, num_labels), -100, dtype=torch.float, device=device)
         elif task_type == 'multiseq':
             num_labels = len(dataset.vocabulary.get_vocab(task))
             golds[task] = torch.full((batch_size, max_token_len, num_labels), -100, dtype=torch.long, device=device)
@@ -174,6 +177,9 @@ def prep_batch(
                     for token_label in token_labels:
                         if token_label != -100:
                             golds[task][instanceIdx][token_idx][token_label] = 1
+            elif task_type == 'probdistr':
+                for label_idx, label in enumerate(instance.golds[task]):
+                    golds[task][instanceIdx][label_idx] = label 
             elif task_type == 'multiclas':
                 for sent_label in instance.golds[task]:
                     if sent_label != -100:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,10 @@
-# Note that networkX is only needed to convert UD-files and uniplot 
-# is optional (but highly recommended)
-
 transformers>=4.0.0
 torch>=1.3.0
 jsonnet
 tqdm
+sentencepiece # for some language models
 #uniplot # Recommended for plots each epoch
 #networkx==2.5 # for cleaning UD
-#sentencepiece # for some language models
-# sacremoses # only for XLMTokenizer
-# protobuf==3.20.0 # only for T5
+#sacremoses # only for XLMTokenizer
+#protobuf==3.20.0 # only for T5
 

--- a/scripts/misc/slurm.py
+++ b/scripts/misc/slurm.py
@@ -20,7 +20,6 @@ def make_file(name, task, idx, time):
     out_file.write('#SBATCH --gres=gpu\n')
     out_file.write('#SBATCH --mem=30G\n')
     out_file.write('#SBATCH --mail-type=BEGIN,END,FAIL\n')
-    out_file.write('#SBATCH --partition=red\n')
 
     out_file.write('\n')
     out_file.write('module load Python/3.9.6-GCCcore-11.2.0\n\n')


### PR DESCRIPTION
- default output of sentence level labels " = " instead of ': '
- updated requirements.txt
- added partial implementation of probdistr (does not work yet)
- Fixed prediction on raw text with conllu format
- removed seed option from config files (they were overwritten in earlier
  versions), you can now only set the seed in the commandline arguments
- default trust_remote_code = False , but new transformer versions give a
  prompt on the command line. The default can easily be updated in
`machamp/model/machamp.py`

Thanks to Verena Blaschke for reporting most of these issues.
